### PR TITLE
Converting ec2 & elb templates to parameter lookup

### DIFF
--- a/ec2.README.md
+++ b/ec2.README.md
@@ -19,17 +19,6 @@ To use this stack you will need to set the required input parameters and include
           "Environment": {
             "Ref": "Environment"
           },
-          "VpcId": {
-            "Ref": "VpcId"
-          },
-          "Subnets": {
-            "Fn::Join": [
-              ",",
-              {
-                "Ref": "Subnets"
-              }
-            ]
-          },
           "AmiId": {
             "Ref": "AmiId"
           },

--- a/ec2.template
+++ b/ec2.template
@@ -21,14 +21,6 @@
       ],
       "ConstraintDescription": "Must specify prod, dev, or sandbox."
     },
-    "VpcId": {
-      "Description": "Id of the VPC",
-      "Type": "String"
-    },
-    "Subnets": {
-      "Description": "Coma, seperated, list, of, subnets",
-      "Type": "CommaDelimitedList"
-    },
     "AmiId": {
       "Description": "The id of the ami for this region",
       "Type": "String"
@@ -53,12 +45,35 @@
     }
   },
   "Resources": {
+    "VpcInfo": {
+      "Type": "Custom::VpcInfo",
+      "Properties": {
+        "ServiceToken": { "Fn::Join": [ "", [ "arn:aws:lambda:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":function:", "LookupStackOutputs" ] ] },
+        "StackName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::Region"
+              },
+              {
+                "Ref": "Environment"
+              },
+              "vpc"
+            ]
+          ]
+        }
+      }
+    },
     "EC2SecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
         "GroupDescription": "Inbound traffic rules",
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::GetAtt": [
+            "VpcInfo",
+            "VpcId"
+          ]
         },
         "SecurityGroupIngress": [
           {
@@ -130,8 +145,18 @@
           {
             "Ref": "EC2SecurityGroup"
           },
-          "sg-e8efef8d",
-          "sg-e9efef8c"
+          {
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "InternetAccessSecurityGroupId"
+            ]
+          },
+          {
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "SharedServicesSecurityGroupId"
+            ]
+          }
         ],
         "InstanceType": {
             "Ref": "InstanceType"
@@ -215,27 +240,21 @@
         },
         "VPCZoneIdentifier": [
           {
-            "Fn::Select": [
-              "0",
-              {
-                "Ref": "Subnets"
-              }
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "PrivateSubnetAZ1"
             ]
           },
           {
-            "Fn::Select": [
-              "1",
-              {
-                "Ref": "Subnets"
-              }
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "PrivateSubnetAZ2"
             ]
           },
           {
-            "Fn::Select": [
-              "2",
-              {
-                "Ref": "Subnets"
-              }
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "PrivateSubnetAZ3"
             ]
           }
         ],

--- a/elb.README.md
+++ b/elb.README.md
@@ -18,17 +18,6 @@ To use this stack you will need to set the required input parameters and include
           },
           "Environment": {
             "Ref": "Environment"
-          },
-          "VpcId": {
-            "Ref": "VpcId"
-          },
-          "Subnets": {
-            "Fn::Join": [
-              ",",
-              {
-                "Ref": "ELBSubnets"
-              }
-            ]
           }
         }
       }

--- a/elb.template
+++ b/elb.template
@@ -20,23 +20,38 @@
         "sandbox"
       ],
       "ConstraintDescription": "Must specify prod, dev, or sandbox."
-    },
-    "VpcId": {
-      "Description": "Id of the VPC",
-      "Type": "String"
-    },
-    "Subnets": {
-      "Description": "Coma, seperated, list, of, subnets",
-      "Type": "CommaDelimitedList"
     }
   },
   "Resources": {
+    "VpcInfo": {
+      "Type": "Custom::VpcInfo",
+      "Properties": {
+        "ServiceToken": { "Fn::Join": [ "", [ "arn:aws:lambda:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":function:", "LookupStackOutputs" ] ] },
+        "StackName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::Region"
+              },
+              {
+                "Ref": "Environment"
+              },
+              "vpc"
+            ]
+          ]
+        }
+      }
+    },
     "ELBSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
         "GroupDescription": "Inbound ELB traffic rules",
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::GetAtt": [
+            "VpcInfo",
+            "VpcId"
+          ]
         },
         "SecurityGroupIngress": [
           {
@@ -84,34 +99,40 @@
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
         "Subnets": [
-           {
-            "Fn::Select": [
-              "0",
-              {
-                "Ref": "Subnets"
-              }
+          {
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "PublicSubnetAZ1"
             ]
           },
           {
-            "Fn::Select": [
-              "1",
-              {
-                "Ref": "Subnets"
-              }
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "PublicSubnetAZ2"
             ]
           },
           {
-            "Fn::Select": [
-              "2",
-              {
-                "Ref": "Subnets"
-              }
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "PublicSubnetAZ3"
             ]
           }
         ],
         "SecurityGroups": [
           {
             "Ref": "ELBSecurityGroup"
+          },
+          {
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "InternetAccessSecurityGroupId"
+            ]
+          },
+          {
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "SharedServicesSecurityGroupId"
+            ]
           }
         ],
         "CrossZone": true,

--- a/lambda/LookupStackOutputs/LookupStackOutputs.README.md
+++ b/lambda/LookupStackOutputs/LookupStackOutputs.README.md
@@ -86,7 +86,7 @@ LAMBDA_ROLL_ARN=$(aws cloudformation describe-stacks --stack-name nubis-lambda-r
 
 Then using the roll arn we set in the environment variable, upload the bundle to Lambda:
 ```bash
-aws lambda upload-function --region us-west-2 --function-name LookupStackOutputs --function-zip lambda/LookupStackOutputs/LookupStackOutputs.zip --runtime nodejs --role ${LAMBDA_ROLL_ARN} --handler LookupStackOutputs.handler --mode event --timeout 10 --memory-size 1024 --description 'Gather outputs from Cloudformation stacks to be used in other Cloudformation stacks'
+aws lambda upload-function --region us-west-2 --function-name LookupStackOutputs --function-zip lambda/LookupStackOutputs/LookupStackOutputs.zip --runtime nodejs --role ${LAMBDA_ROLL_ARN} --handler LookupStackOutputs.handler --mode event --timeout 10 --memory-size 128 --description 'Gather outputs from Cloudformation stacks to be used in other Cloudformation stacks'
 ```
 
 If everything worked as expected you should see some output similar to this:
@@ -95,7 +95,7 @@ If everything worked as expected you should see some output similar to this:
     "FunctionName": "LookupStackOutputs", 
     "CodeSize": 1397, 
     "ConfigurationId": "92c44c94-b648-423c-ab6f-79db6fef7930", 
-    "MemorySize": 1024, 
+    "MemorySize": 128, 
     "FunctionARN": "arn:aws:lambda:us-west-2:647505682097:function:LookupStackOutputs", 
     "Handler": "LookupStackOutputs.handler", 
     "Role": "arn:aws:iam::647505682097:role/nubis-lambda-roll-LambdaIamRole-15M0SCFBIWYQE", 


### PR DESCRIPTION
Converting to the new lambda lookup schema. Changes were made to the VPC outputs to support this method.

Also updated the memry of the lambda function after some testing. The average execution memory was 15M sO I reduced to 128M which is the smalest allowed.
