### PR TITLE
Fixed typo

### DIFF
--- a/rds-postgres.template
+++ b/rds-postgres.template
@@ -116,7 +116,7 @@
         "DBSubnetGroupName": {
           "Ref": "RDSSubnetGroup"
         },
-        "Engine": "PostgreSQL",
+        "Engine": "postgres",
         "EngineVersion": "9.3",
         "MultiAZ": "true",
         "BackupRetentionPeriod": "7",


### PR DESCRIPTION
Fixed typo, postgresql != postgres, referenced here http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
