### PR TITLE
Add a new SSLCertificate argument to the ELB Stack, if specified, its the ARN of the SSL certificate to use, otherwise, defaults to a shared cert.

### DIFF
--- a/elb.README.md
+++ b/elb.README.md
@@ -19,7 +19,8 @@ To use this stack you will need to set the required input parameters and include
           "Environment": {
             "Ref": "Environment"
           },
-          "ElbHealthTarget": "HTTP:80/index.html"
+          "ElbHealthTarget": "HTTP:80/index.html",
+          "SSLCertificate": "arn:aws:iam::<account-id>:server-certificate/<cert-name>" [optionnal]
         }
       }
     }

--- a/elb.template
+++ b/elb.template
@@ -28,6 +28,29 @@
     }
   },
   "Resources": {
+    "MetaInfo": {
+      "Type": "Custom::VpcInfo",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:lambda:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":function:",
+              "LookupStackOutputs"
+            ]
+          ]
+        },
+        "StackName": "nubis-meta"
+      }
+    },
     "VpcInfo": {
       "Type": "Custom::VpcInfo",
       "Properties": {
@@ -169,6 +192,13 @@
             "InstanceProtocol": "HTTP",
             "LoadBalancerPort": "80",
             "Protocol": "HTTP"
+          },
+          {
+            "InstancePort": "80",
+            "InstanceProtocol": "HTTP",
+            "LoadBalancerPort": "443",
+            "Protocol": "HTTPS",
+            "SSLCertificateId": { "Fn::GetAtt": [ "MetaInfo", "DefaultServerCertificate" ] }
           }
         ],
         "HealthCheck": {

--- a/elb.template
+++ b/elb.template
@@ -25,6 +25,21 @@
       "Description": "The protocol and url to use for checking the health of the service",
       "Type": "String",
       "Default": "HTTP:80/"
+    },
+    "SSLCertificate": {
+      "Description": "The ARN of the SSL cerftificate to use for this ELB",
+      "Type": "String",
+      "Default": ""
+    }
+  },
+  "Conditions": {
+    "NotSet_SSLCertificate": {
+      "Fn::Equals": [
+        {
+          "Ref": "SSLCertificate"
+        },
+        ""
+      ]
     }
   },
   "Resources": {
@@ -198,7 +213,20 @@
             "InstanceProtocol": "HTTP",
             "LoadBalancerPort": "443",
             "Protocol": "HTTPS",
-            "SSLCertificateId": { "Fn::GetAtt": [ "MetaInfo", "DefaultServerCertificate" ] }
+            "SSLCertificateId": {
+              "Fn::If": [
+                "NotSet_SSLCertificate",
+                {
+                  "Fn::GetAtt": [
+                    "MetaInfo",
+                    "DefaultServerCertificate"
+                  ]
+                },
+                {
+                  "Ref": "SSLCertificate"
+                }
+              ]
+            }
           }
         ],
         "HealthCheck": {


### PR DESCRIPTION
Fixes #42
