### PR TITLE
Add Name tag for autoscaling group

### DIFF
--- a/ec2.template
+++ b/ec2.template
@@ -410,6 +410,13 @@
         ],
         "Tags": [
           {
+            "Key": "Name",
+            "Value": {
+              "Ref": "ServiceName"
+            },
+            "PropagateAtLaunch": "true"
+          },
+          {
             "Key": "ServiceName",
             "Value": {
               "Ref": "ServiceName"


### PR DESCRIPTION
Not sure if this is left out intentionally but adding the name tag will make it easier for people to find their EC2 instance at a glance on the amazon console. At the moment when I need to look for my EC2 instance on the amazon console, I end up having to search for it using the search box. This PR hopefully will help with making it easier to find your EC2 instance
