### PR TITLE
Removing ProjectName parameter from README files

### DIFF
--- a/ec2.README.md
+++ b/ec2.README.md
@@ -37,9 +37,6 @@ To use this stack you will need to set the required input parameters and include
           "SSHKeyName": {
             "Ref": "SSHKeyName"
           },
-          "ProjectName": {
-            "Ref": "ProjectName"
-          },
           "SubnetLocation": {
             "Ref": "SubnetLocation"
           },

--- a/s3-bucket.README.md
+++ b/s3-bucket.README.md
@@ -22,9 +22,6 @@ To use this stack you will need to set the required input parameters and include
           "ServiceName": {
             "Ref": "ServiceName"
           },
-          "ProjectName": {
-            "Ref": "ProjectName"
-          },
           "Environment": {
             "Ref": "Environment"
           },


### PR DESCRIPTION
ProjectName argument is not used in any stack so removing this to avoid confusion
