### PR TITLE
Iam instance profile stack

### DIFF
--- a/iam-instance-profile.README.md
+++ b/iam-instance-profile.README.md
@@ -1,0 +1,29 @@
+## IAM instance profile stack
+
+To use this stack you will need to set the required input parameter to include the stack as a resource
+
+#### Example input definition
+```json
+    "StacksVersion": {
+      "Description": "Version of the Nubis Stacks",
+      "Type": "String",
+      "Default": "v1.0.0"
+    },
+```
+#### Example resource definition
+```json
+    "IAMRoleStack": {
+        "Type": "AWS::CloudFormation::Stack",
+        "Properties": {
+            "TemplateURL": { "Fn::Join": [ "/", [ "https://s3.amazonaws.com/nubisproject-stacks", { "Ref": "StacksVersion" }, "iam-instance-profile.template" ] ] },
+            "TimeoutInMinutes": "60",
+            "Parameters": {
+                "IAMRoles": { "Fn::GetAtt": [ "MyStackThatReturnsAnIAMRole", "Outputs.IAMRole"] }
+            }
+        }
+    }
+```
+
+#### Return values
+
+* `IAMInstanceProfileName` - Name of IAM instance profile which you can then reference to on your EC2 instance

--- a/iam-instance-profile.template
+++ b/iam-instance-profile.template
@@ -4,7 +4,7 @@
   "Parameters": {
     "IAMRoles": {
       "Description": "IAM instance profile name",
-      "Type": "CommaDelimitedList"
+      "Type": "String"
     }
   },
   "Resources": {

--- a/iam-instance-profile.template
+++ b/iam-instance-profile.template
@@ -4,7 +4,7 @@
   "Parameters": {
     "IAMRoles": {
       "Description": "IAM instance profile name",
-      "Type": "String"
+      "Type": "CommaDelimitedList"
     }
   },
   "Resources": {

--- a/iam-instance-profile.template
+++ b/iam-instance-profile.template
@@ -1,0 +1,31 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Attach role to IAM Instance profile",
+  "Parameters": {
+    "IAMRoles": {
+      "Description": "IAM instance profile name",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "IAMInstanceProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Path": "/",
+        "Roles": [
+          {
+            "Ref": "IAMRoles"
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "IAMInstanceProfileName": {
+      "Description": "Name of IAM Instance profile",
+      "Value": {
+        "Ref": "IAMInstanceProfile"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a generic stack to attach an IAM role to an IAM instance profile, the reason why we split it out this way is because there can only be 1 IAM profile per EC2 instance however there can be multiple policies per IAM role. So we allow users to generate as many policies as they want and at the end they just have to attach it to this instance profile stack
