### PR TITLE
S3 backup bucket with IAM roles

### DIFF
--- a/s3-bucket.template
+++ b/s3-bucket.template
@@ -49,6 +49,33 @@
         "Enabled",
         "Suspended"
       ]
+    },
+    "Ec2Backups": {
+      "Description": "Create s3 bucket for ec2 instance with associated IAM roles",
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": [
+        "true",
+        "false"
+      ]
+    }
+  },
+  "Conditions": {
+    "Ec2BackupsEnable": {
+      "Fn::Equals": [
+        {
+          "Ref": "Ec2Backups"
+        },
+        "true"
+      ]
+    },
+    "Ec2BackupsDisable": {
+      "Fn::Equals": [
+        {
+          "Ref": "Ec2Backups"
+        },
+        "false"
+      ]
     }
   },
   "Resources": {
@@ -99,6 +126,94 @@
           }
         ]
       }
+    },
+    "S3BackupIAMRole": {
+      "Type": "AWS::IAM::Role",
+      "Condition": "Ec2BackupsEnable",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Path": "/"
+      }
+    },
+    "S3BackupIAMPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "Ec2BackupsEnable",
+      "Properties": {
+        "PolicyName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "backup",
+              "policy"
+            ]
+          ]
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:ListBucket"
+              ],
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "S3Bucket"
+                    }
+                  ]
+                ]
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:DeleteObject"
+              ],
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "S3Bucket"
+                    },
+                    "/*"
+                  ]
+                ]
+              }
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "S3BackupIAMRole"
+          }
+        ]
+      }
     }
   },
   "Outputs": {
@@ -115,6 +230,13 @@
           "S3Bucket",
           "DomainName"
         ]
+      }
+    },
+    "S3BackupIAMRole": {
+      "Description": "IAM role for S3 Backup bucket",
+      "Condition": "Ec2BackupsEnable",
+      "Value": {
+        "Ref": "S3BackupIAMRole"
       }
     }
   }

--- a/s3-bucket.template
+++ b/s3-bucket.template
@@ -50,7 +50,7 @@
         "Suspended"
       ]
     },
-    "S3Storage": {
+    "WithRole": {
       "Description": "Create s3 bucket for ec2 instance with associated IAM roles",
       "Type": "String",
       "Default": "false",
@@ -61,18 +61,18 @@
     }
   },
   "Conditions": {
-    "S3StorageEnable": {
+    "WithRoleEnable": {
       "Fn::Equals": [
         {
-          "Ref": "S3Storage"
+          "Ref": "WithRole"
         },
         "true"
       ]
     },
-    "S3StorageDisable": {
+    "WithRoleDisable": {
       "Fn::Equals": [
         {
-          "Ref": "S3Storage"
+          "Ref": "WithRole"
         },
         "false"
       ]
@@ -129,7 +129,7 @@
     },
     "S3BackupIAMRole": {
       "Type": "AWS::IAM::Role",
-      "Condition": "S3StorageEnable",
+      "Condition": "WithRoleEnable",
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
@@ -152,7 +152,7 @@
     },
     "S3BackupIAMPolicy": {
       "Type": "AWS::IAM::Policy",
-      "Condition": "S3StorageEnable",
+      "Condition": "WithRoleEnable",
       "Properties": {
         "PolicyName": {
           "Fn::Join": [
@@ -232,9 +232,9 @@
         ]
       }
     },
-    "S3BackupIAMRole": {
+    "S3Role": {
       "Description": "IAM role for S3 Backup bucket",
-      "Condition": "S3StorageEnable",
+      "Condition": "WithRoleEnable",
       "Value": {
         "Ref": "S3BackupIAMRole"
       }

--- a/s3-bucket.template
+++ b/s3-bucket.template
@@ -50,7 +50,7 @@
         "Suspended"
       ]
     },
-    "Ec2Backups": {
+    "S3Storage": {
       "Description": "Create s3 bucket for ec2 instance with associated IAM roles",
       "Type": "String",
       "Default": "false",
@@ -61,18 +61,18 @@
     }
   },
   "Conditions": {
-    "Ec2BackupsEnable": {
+    "S3StorageEnable": {
       "Fn::Equals": [
         {
-          "Ref": "Ec2Backups"
+          "Ref": "S3Storage"
         },
         "true"
       ]
     },
-    "Ec2BackupsDisable": {
+    "S3StorageDisable": {
       "Fn::Equals": [
         {
-          "Ref": "Ec2Backups"
+          "Ref": "S3Storage"
         },
         "false"
       ]
@@ -129,7 +129,7 @@
     },
     "S3BackupIAMRole": {
       "Type": "AWS::IAM::Role",
-      "Condition": "Ec2BackupsEnable",
+      "Condition": "S3StorageEnable",
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
@@ -152,7 +152,7 @@
     },
     "S3BackupIAMPolicy": {
       "Type": "AWS::IAM::Policy",
-      "Condition": "Ec2BackupsEnable",
+      "Condition": "S3StorageEnable",
       "Properties": {
         "PolicyName": {
           "Fn::Join": [
@@ -234,7 +234,7 @@
     },
     "S3BackupIAMRole": {
       "Description": "IAM role for S3 Backup bucket",
-      "Condition": "Ec2BackupsEnable",
+      "Condition": "S3StorageEnable",
       "Value": {
         "Ref": "S3BackupIAMRole"
       }


### PR DESCRIPTION
Create a configurable flag that will create an IAM role to enable an EC2 instance to access an s3 bucket within the instance. The stack will create everything except for the IAM instance profile which should get created by a separate stack (PR #84)

This PR also fixes issue #43 
