### PR TITLE
Updated eip README

### DIFF
--- a/eip.README.md
+++ b/eip.README.md
@@ -35,3 +35,9 @@ To use this stack you will need to set the required input parameters and include
 
 #### Notes
 * This stack requires the `--capabilities CAPABILITY_IAM` flag when calling aws cli
+
+* This stack will also need to be used in conjunction with the nubis-puppet-eip puppet module, this module will associate an EIP to the instance
+
+```
+include nubis::eip
+```


### PR DESCRIPTION
Updated EIP readme, EIP needs to be used with a puppet module in order to associated an EIP to an instance
