### PR TITLE
Add optional argument SecurityGroup, if present, uses it as the security group for EC2 instances instead of the default.

### DIFF
--- a/ec2.template
+++ b/ec2.template
@@ -139,6 +139,11 @@
       "Description": "Optionnal ACL Token for Consul",
       "Type": "String",
       "Default": "anonymous"
+    },
+    "SecurityGroup": {
+      "Description": "Optionnal Security Group for instances",
+      "Type": "String",
+      "Default": ""
     }
   },
   "Conditions": {
@@ -154,6 +159,14 @@
       "Fn::Equals": [
         {
           "Ref": "ELB"
+        },
+        ""
+      ]
+    },
+    "NotSet_SecurityGroup": {
+      "Fn::Equals": [
+        {
+          "Ref": "SecurityGroup"
         },
         ""
       ]
@@ -218,6 +231,7 @@
     },
     "EC2SecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
+      "Condition": "NotSet_SecurityGroup",
       "Properties": {
         "GroupDescription": "Inbound traffic rules",
         "VpcId": {
@@ -237,18 +251,6 @@
             "IpProtocol": "tcp",
             "FromPort": "80",
             "ToPort": "80",
-            "CidrIp": "0.0.0.0/0"
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "8300",
-            "ToPort": "8303",
-            "CidrIp": "0.0.0.0/0"
-          },
-          {
-            "IpProtocol": "udp",
-            "FromPort": "8300",
-            "ToPort": "8303",
             "CidrIp": "0.0.0.0/0"
           }
         ],
@@ -302,9 +304,12 @@
           "Ref": "AmiId"
         },
         "SecurityGroups": [
-          {
-            "Ref": "EC2SecurityGroup"
-          },
+           {
+           "Fn::If": [
+            "NotSet_SecurityGroup",
+            { "Ref": "EC2SecurityGroup" },
+            { "Ref": "SecurityGroup" }
+          ]},
           {
             "Fn::GetAtt": [
               "VpcInfo",
@@ -641,12 +646,14 @@
   },
   "Outputs": {
     "EC2SecurityGroup": {
+      "Condition": "NotSet_SecurityGroup",
       "Description": "EC2SecurityGroup Id",
       "Value": {
         "Ref": "EC2SecurityGroup"
       }
     },
     "GroupId": {
+      "Condition": "NotSet_SecurityGroup",
       "Description": "EC2SecurityGroup Group Id",
       "Value": {
         "Fn::GetAtt": [


### PR DESCRIPTION
Fixes #90
