### PR TITLE
Rewrite VPC templates for multiple accounts

### DIFF
--- a/bin/upload_to_s3
+++ b/bin/upload_to_s3
@@ -17,23 +17,47 @@ if [ -f "bin/variables" ]; then
 fi
 
 declare -a FILES_LIST
+
+validate-file () {
+    echo -n "Validating $1: "
+    aws cloudformation validate-template --template-body file://$1 > /dev/null
+    if [ "$?" = "0" ]; then
+        echo "Passed"
+        FILES_LIST=(${FILES_LIST[@]} $1)
+    else
+        echo "Failed! Excluding from upload."
+    fi
+}
+
 get_files_list () {
-    # Include all markdown files
-    FILES=`find . -maxdepth 1 -name "*.md" | xargs -n1 basename`
+    # Find all files that are not part of automation or configuration
+    FILES=`find . \
+                -name . -a -type d -o \
+                -name .git -a -type d -prune -o \
+                -name bin -a -type d -prune -o \
+                -name nubis -a -type d -prune -o \
+                -name lambda -a -type d -prune -o \
+                -name parameters -a -type d -prune -o \
+                -name vpc -a -type d -o \
+                -name README.md -a -type f -o \
+                -name CHANGELOG.md -a -type f -o \
+                -name LICENSE -a -type f -o \
+                -name parameters.json-dist -a -type f -o \
+                -name template-dist -a -type f -o \
+                -name .gitignore -a -type f -o \
+                -print | sed 's|^./||'`
+
+    # Include all markdown (README.md) files
     for FILE in $FILES; do
-        FILES_LIST=(${FILES_LIST[@]} $FILE)
+        if [[ $FILE == *\.README.md ]]; then
+            FILES_LIST=(${FILES_LIST[@]} $FILE)
+        fi
     done
 
-    # Include all template files
-    FILES=`find . -maxdepth 1 -name "*.template" | xargs -n1 basename`
+    # Include all template files that pass validation
     for FILE in $FILES; do
-        echo -n "$FILE Valid: "
-        aws cloudformation validate-template --template-body file://$FILE > /dev/null
-        if [ "$?" = "0" ]; then
-          echo "ok"
-          FILES_LIST=(${FILES_LIST[@]} $FILE)
-        else
-          echo "failed"
+        if [[ $FILE == *\.template ]]; then
+            validate-file $FILE
         fi
     done
 }
@@ -107,7 +131,7 @@ while [ "$1" != "" ]; do
             if [ -z $2 ]; then
                 get_files_list
             else
-                FILES_LIST=$2
+                validate-file $2
             fi
             push-files
             GOT_COMMAND=1

--- a/vpc/vpc-private-subnet.README.md
+++ b/vpc/vpc-private-subnet.README.md
@@ -1,0 +1,61 @@
+﻿## VPC Private Subnet Nested Stack
+
+To use this stack you will need to set the required input parameters and include the stack as a resource.
+
+#### Example input definition
+```json
+    "StacksVersion": {
+      "Description": "Version of Nubis Stacks to use for the nested stacks.",
+      "Type": "String",
+      "Default": "v1.0.0"
+    },
+```
+
+#### Example resource definition
+```json
+    "PrivateSubnetStack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "TemplateURL": { "Fn::Join": [ "/", [ "https://s3.amazonaws.com/nubisproject-stacks", { "Ref": "StacksVersion" }, "vpc/vpc-private-subnet.template" ] ] },
+        "TimeoutInMinutes": "60",
+        "Parameters": {
+          "VpcId": {
+            "Ref": "NubisVpc"
+          },
+          "ServiceName": {
+            "Ref": "ServiceName"
+          },
+          "TechnicalOwner": {
+            "Ref": "TechnicalOwner"
+          },
+          "Environment": {
+            "Ref": "Environment"
+          },
+          "PrivateSubnetAZ1Cidr": {
+            "Ref": "PrivateSubnetAZ1Cidr"
+          },
+          "PrivateSubnetAZ2Cidr": {
+            "Ref": "PrivateSubnetAZ2Cidr"
+          },
+          "PrivateSubnetAZ3Cidr": {
+            "Ref": "PrivateSubnetAZ3Cidr"
+          },
+          "SSHKeyName": {
+            "Ref": "SSHKeyName"
+          },
+          "PublicSubnetAZ1": {
+            "Ref": "PrivateSubnetAZ2Cidr"
+          },
+          "PublicSubnetAZ2": {
+            "Ref": "PrivateSubnetAZ2Cidr"
+          },
+          "PublicSubnetAZ3": {
+            "Ref": "PrivateSubnetAZ3Cidr"
+          },
+          "InternetAccessSecurityGroup": {
+            "Ref": "InternetAccessSecurityGroup"
+          }
+        }
+      }
+    }
+```

--- a/vpc/vpc-private-subnet.template
+++ b/vpc/vpc-private-subnet.template
@@ -1,0 +1,658 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "3 private subnets and 3 NATs across 3 availability zones in a VPC",
+  "Parameters": {
+    "VpcId": {
+      "Description": "The VPC ID we are deploying assets into.",
+      "Type": "AWS::EC2::VPC::Id"
+    },
+    "ServiceName": {
+      "Description": "Name of this deployment",
+      "AllowedPattern": "^[a-z0-9][a-z0-9-.]*$",
+      "Type": "String"
+    },
+    "TechnicalOwner": {
+      "Description": "A valid LDAP email",
+      "AllowedPattern": "^([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$",
+      "Type": "String"
+    },
+    "Environment": {
+      "Description": "The name of the environment we are deploying into: sandbox, stage, or production.",
+      "Type": "String",
+      "AllowedValues": [
+        "sandbox",
+        "stage",
+        "prod",
+        "admin"
+      ],
+      "Default": "sandbox",
+      "ConstraintDescription": "Must be one of these types of VPCs"
+    },
+    "PrivateSubnetAZ1Cidr": {
+      "Description": "The CIDR for the Private Subnet in Availability Zone 1.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "PrivateSubnetAZ2Cidr": {
+      "Description": "The CIDR for the Private Subnet in Availability Zone 2.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "PrivateSubnetAZ3Cidr": {
+      "Description": "The CIDR for the Private Subnet in Availability Zone 3.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "SSHKeyName": {
+      "Description": "Name of an existing EC2 SSH KeyPair to install on the instance",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription": "Must be the name of an existing EC2 KeyPair."
+    },
+    "PublicSubnetAZ1": {
+      "Description": "The ID of the Public Subnet in Availability Zone 1.",
+      "Type": "AWS::EC2::Subnet::Id"
+    },
+    "PublicSubnetAZ2": {
+      "Description": "The ID of the Public Subnet in Availability Zone 2.",
+      "Type": "AWS::EC2::Subnet::Id"
+    },
+    "PublicSubnetAZ3": {
+      "Description": "The ID of the Public Subnet in Availability Zone 3.",
+      "Type": "AWS::EC2::Subnet::Id"
+    },
+    "InternetAccessSecurityGroup": {
+      "Description": "Security group FROM which we allow traffic TO the NAT instances.",
+      "Type": "AWS::EC2::SecurityGroup::Id"
+    }
+  },
+  "Mappings": {
+    "AWSNATAMI": {
+      "us-east-1": {
+        "AMI": "ami-c6699baf"
+      },
+      "us-west-2": {
+        "AMI": "ami-52ff7262"
+      }
+    },
+    "Region2AZ": {
+      "us-east-1": {
+        "AZ1": "us-east-1b",
+        "AZ2": "us-east-1c",
+        "AZ3": "us-east-1d"
+      },
+      "us-west-2": {
+        "AZ1": "us-west-2a",
+        "AZ2": "us-west-2b",
+        "AZ3": "us-west-2c"
+      }
+    }
+  },
+  "Resources": {
+    "PrivateSubnetAZ1": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "AvailabilityZone": {
+          "Fn::FindInMap": [
+            "Region2AZ",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AZ1"
+          ]
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnetAZ1Cidr"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PrivateSubnetAZ1"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "PrivateSubnetAZ2": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "AvailabilityZone": {
+          "Fn::FindInMap": [
+            "Region2AZ",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AZ2"
+          ]
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnetAZ2Cidr"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PrivateSubnetAZ2"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "PrivateSubnetAZ3": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "AvailabilityZone": {
+          "Fn::FindInMap": [
+            "Region2AZ",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AZ3"
+          ]
+        },
+        "CidrBlock": {
+          "Ref": "PrivateSubnetAZ3Cidr"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PrivateSubnetAZ3"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "PrivateRouteTableAZ1": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PrivateSubnet1AZRouteTable"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "PrivateRouteTableAZ2": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PrivateSubnet2AZRouteTable"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "PrivateRouteTableAZ3": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PrivateSubnet3AZRouteTable"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "PrivateSubnetAZ1RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnetAZ1"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ1"
+        }
+      }
+    },
+    "PrivateSubnetAZ2RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnetAZ2"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ2"
+        }
+      }
+    },
+    "PrivateSubnetAZ3RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnetAZ3"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ3"
+        }
+      }
+    },
+    "PrivateRouteAZ1": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ1"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Ref": "NatInstanceAZ1"
+        }
+      }
+    },
+    "PrivateRouteAZ2": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ2"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Ref": "NatInstanceAZ2"
+        }
+      }
+    },
+    "PrivateRouteAZ3": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ3"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Ref": "NatInstanceAZ3"
+        }
+      }
+    },
+    "NatSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "NAT Security Group",
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "SourceSecurityGroupId": {
+              "Ref": "InternetAccessSecurityGroup"
+            }
+          },
+          {
+            "IpProtocol": "udp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "SourceSecurityGroupId": {
+              "Ref": "InternetAccessSecurityGroup"
+            }
+          },
+          {
+            "IpProtocol": "icmp",
+            "FromPort": "8",
+            "ToPort": "-1",
+            "SourceSecurityGroupId": {
+              "Ref": "InternetAccessSecurityGroup"
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "NATSecurityGroup"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": "Netops"
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "NatInstanceAZ1": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "KeyName": {
+          "Ref": "SSHKeyName"
+        },
+        "SourceDestCheck": "false",
+        "ImageId": {
+          "Fn::FindInMap": [
+            "AWSNATAMI",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AMI"
+          ]
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "NatSecurityGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "SubnetId": {
+              "Ref": "PublicSubnetAZ1"
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "NatInstanceAZ1"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "NatInstanceAZ2": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "KeyName": {
+          "Ref": "SSHKeyName"
+        },
+        "SourceDestCheck": "false",
+        "ImageId": {
+          "Fn::FindInMap": [
+            "AWSNATAMI",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AMI"
+          ]
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "NatSecurityGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "SubnetId": {
+              "Ref": "PublicSubnetAZ2"
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "NatInstanceAZ2"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "NatInstanceAZ3": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "KeyName": {
+          "Ref": "SSHKeyName"
+        },
+        "SourceDestCheck": "false",
+        "ImageId": {
+          "Fn::FindInMap": [
+            "AWSNATAMI",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AMI"
+          ]
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "NatSecurityGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "SubnetId": {
+              "Ref": "PublicSubnetAZ3"
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "NatInstanceAZ3"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "PrivateRouteTableAZ1": {
+      "Value": {
+        "Ref": "PrivateRouteTableAZ1"
+      }
+    },
+    "PrivateRouteTableAZ2": {
+      "Value": {
+        "Ref": "PrivateRouteTableAZ2"
+      }
+    },
+    "PrivateRouteTableAZ3": {
+      "Value": {
+        "Ref": "PrivateRouteTableAZ3"
+      }
+    },
+    "PrivateSubnetAZ1": {
+      "Value": {
+        "Ref": "PrivateSubnetAZ1"
+      }
+    },
+    "PrivateSubnetAZ2": {
+      "Value": {
+        "Ref": "PrivateSubnetAZ2"
+      }
+    },
+    "PrivateSubnetAZ3": {
+      "Value": {
+        "Ref": "PrivateSubnetAZ3"
+      }
+    }
+  }
+}

--- a/vpc/vpc-public-subnet.README.md
+++ b/vpc/vpc-public-subnet.README.md
@@ -1,0 +1,46 @@
+﻿## VPC Public Subnet Nested Stack
+
+To use this stack you will need to set the required input parameters and include the stack as a resource.
+
+#### Example input definition
+```json
+    "StacksVersion": {
+      "Description": "Version of Nubis Stacks to use for the nested stacks.",
+      "Type": "String",
+      "Default": "v1.0.0"
+    },
+```
+
+#### Example resource definition
+```json
+    "PublicSubnetStack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "TemplateURL": { "Fn::Join": [ "/", [ "https://s3.amazonaws.com/nubisproject-stacks", { "Ref": "StacksVersion" }, "vpc/vpc-public-subnet.template" ] ] },
+        "TimeoutInMinutes": "60",
+        "Parameters": {
+          "VpcId": {
+            "Ref": "NubisVpc"
+          },
+          "ServiceName": {
+            "Ref": "ServiceName"
+          },
+          "TechnicalOwner": {
+            "Ref": "TechnicalOwner"
+          },
+          "Environment": {
+            "Ref": "Environment"
+          },
+          "PublicSubnetAZ1Cidr": {
+            "Ref": "PublicSubnetAZ1Cidr"
+          },
+          "PublicSubnetAZ2Cidr": {
+            "Ref": "PublicSubnetAZ2Cidr"
+          },
+          "PublicSubnetAZ3Cidr": {
+            "Ref": "PublicSubnetAZ3Cidr"
+          }
+        }
+      }
+    }
+```

--- a/vpc/vpc-public-subnet.template
+++ b/vpc/vpc-public-subnet.template
@@ -1,0 +1,345 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "3 public subnets across 3 availability zones in a VPC",
+  "Parameters": {
+    "VpcId": {
+      "Description": "The VPC ID to attach this vpn onto.",
+      "Type": "AWS::EC2::VPC::Id"
+    },
+    "ServiceName": {
+      "Description": "Name of this deployment",
+      "AllowedPattern": "^[a-z0-9][a-z0-9-.]*$",
+      "Type": "String"
+    },
+    "TechnicalOwner": {
+      "Description": "A valid LDAP email",
+      "AllowedPattern": "^([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$",
+      "Type": "String"
+    },
+    "Environment": {
+      "Description": "The name of the environment we are deploying into: sandbox, stage, or production.",
+      "Type": "String",
+      "AllowedValues": [
+        "sandbox",
+        "stage",
+        "prod",
+        "admin"
+      ],
+      "Default": "sandbox",
+      "ConstraintDescription": "Must be one of these types of Mozilla VPCs"
+    },
+    "PublicSubnetAZ1Cidr": {
+      "Description": "The CIDR for the Public Subnet in Availability Zone 1.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "PublicSubnetAZ2Cidr": {
+      "Description": "The CIDR for the Public Subnet in Availability Zone 2.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "PublicSubnetAZ3Cidr": {
+      "Description": "The CIDR for the Public Subnet in Availability Zone 3.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    }
+  },
+  "Mappings": {
+    "Region2AZ": {
+      "us-east-1": {
+        "AZ1": "us-east-1b",
+        "AZ2": "us-east-1c",
+        "AZ3": "us-east-1d"
+      },
+      "us-west-2": {
+        "AZ1": "us-west-2a",
+        "AZ2": "us-west-2b",
+        "AZ3": "us-west-2c"
+      }
+    }
+  },
+  "Resources": {
+    "InternetGateway": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "InternetGateway"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "InternetGatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "DependsOn": "InternetGateway",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "InternetGatewayId": {
+          "Ref": "InternetGateway"
+        }
+      }
+    },
+    "PublicRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PublicRouteTable"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "DefaultRoute": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "InternetGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "InternetGateway"
+        }
+      }
+    },
+    "PublicSubnetAZ1": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "AvailabilityZone": {
+          "Fn::FindInMap": [
+            "Region2AZ",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AZ1"
+          ]
+        },
+        "CidrBlock": {
+          "Ref": "PublicSubnetAZ1Cidr"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PublicSubnetAZ1"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "PublicSubnetAZ2": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "AvailabilityZone": {
+          "Fn::FindInMap": [
+            "Region2AZ",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AZ2"
+          ]
+        },
+        "CidrBlock": {
+          "Ref": "PublicSubnetAZ2Cidr"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PublicSubnetAZ2"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "PublicSubnetAZ3": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "AvailabilityZone": {
+          "Fn::FindInMap": [
+            "Region2AZ",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AZ3"
+          ]
+        },
+        "CidrBlock": {
+          "Ref": "PublicSubnetAZ3Cidr"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "PublicSubnetAZ3"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "PublicSubnetAZ1RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PublicSubnetAZ1"
+        },
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        }
+      }
+    },
+    "PublicSubnetAZ2RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PublicSubnetAZ2"
+        },
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        }
+      }
+    },
+    "PublicSubnetAZ3RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PublicSubnetAZ3"
+        },
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "PublicRouteTable": {
+      "Value": {
+        "Ref": "PublicRouteTable"
+      }
+    },
+    "PublicSubnetAZ1": {
+      "Value": {
+        "Ref": "PublicSubnetAZ1"
+      }
+    },
+    "PublicSubnetAZ2": {
+      "Value": {
+        "Ref": "PublicSubnetAZ2"
+      }
+    },
+    "PublicSubnetAZ3": {
+      "Value": {
+        "Ref": "PublicSubnetAZ3"
+      }
+    }
+  }
+}

--- a/vpc/vpc-vpn.README.md
+++ b/vpc/vpc-vpn.README.md
@@ -1,0 +1,52 @@
+﻿## VPC VPN Nested Stack
+
+To use this stack you will need to set the required input parameters and include the stack as a resource.
+
+#### Example input definition
+```json
+    "StacksVersion": {
+      "Description": "Version of Nubis Stacks to use for the nested stacks.",
+      "Type": "String",
+      "Default": "v1.0.0"
+    },
+```
+
+#### Example resource definition
+```json
+    "VPNStack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "TemplateURL": { "Fn::Join": [ "/", [ "https://s3.amazonaws.com/nubisproject-stacks", { "Ref": "StacksVersion" }, "vpc/vpc-vpn.template" ] ] },
+        "TimeoutInMinutes": "60",
+        "Parameters": {
+          "VpcId": {
+            "Ref": "NubisVpc"
+          },
+          "ServiceName": {
+            "Ref": "ServiceName"
+          },
+          "TechnicalOwner": {
+            "Ref": "TechnicalOwner"
+          },
+          "Environment": {
+            "Ref": "Environment"
+          },
+          "PublicRouteTable": {
+            "Ref": "PublicRouteTable"
+          },
+          "PrivateRouteTableAZ1": {
+            "Ref": "PrivateRouteTableAZ1"
+          },
+          "PrivateRouteTableAZ2": {
+            "Ref": "PrivateRouteTableAZ2"
+          },
+          "PrivateRouteTableAZ3": {
+            "Ref": "PrivateRouteTableAZ3"
+          },
+          "IPSecTunnelTarget": {
+            "Ref": "IPSecTunnelTarget"
+          }
+        }
+      }
+    }
+```

--- a/vpc/vpc-vpn.template
+++ b/vpc/vpc-vpn.template
@@ -1,0 +1,319 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "A VPN connection from a VPC to an endpoint in a datacenter",
+  "Parameters": {
+    "VpcId": {
+      "Description": "The VPC ID to attach this vpn onto.",
+      "Type": "AWS::EC2::VPC::Id"
+    },
+    "ServiceName": {
+      "Description": "Name of this deployment",
+      "AllowedPattern": "^[a-z0-9][a-z0-9-.]*$",
+      "Type": "String"
+    },
+    "TechnicalOwner": {
+      "Description": "A valid LDAP email",
+      "AllowedPattern": "^([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$",
+      "Type": "String"
+    },
+    "Environment": {
+      "Description": "The name of the environment we are deploying into: sandbox, stage, or production.",
+      "Type": "String",
+      "AllowedValues": [
+        "sandbox",
+        "stage",
+        "prod",
+        "admin"
+      ],
+      "Default": "sandbox",
+      "ConstraintDescription": "Must be one of these types of Mozilla VPCs"
+    },
+    "PublicRouteTable": {
+      "Description": "The ID of the Public Route Table",
+      "Type": "String"
+    },
+    "PrivateRouteTableAZ1": {
+      "Description": "The ID of the Private Route Table in Avalibility Zone 1.",
+      "Type": "String"
+    },
+    "PrivateRouteTableAZ2": {
+      "Description": "The ID of the Private Route Table in Avalibility Zone 2.",
+      "Type": "String"
+    },
+    "PrivateRouteTableAZ3": {
+      "Description": "The ID of the Private Route Table in Avalibility Zone 3.",
+      "Type": "String"
+    },
+    "BgpAutonomousSystemNumber": {
+      "Description": "The ASN of Mozilla's router in our datacenter",
+      "Type": "Number",
+      "MinValue": "1",
+      "MaxValue": "65536",
+      "Default": "65022"
+    },
+    "IPSecTunnelTarget": {
+      "Description": "The IP address of our firewall where the IPSec tunnels will terminate",
+      "Type": "String",
+      "MinLength": "7",
+      "MaxLength": "15",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x"
+    },
+    "DataCenterCidrBlock": {
+      "Description": "The CIDR range of our datacenter for routing traffic.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "Default": "10.0.0.0/10",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "OfficeCidrBlock": {
+      "Description": "The CIDR range of our office for routing traffic.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "Default": "10.192.0.0/10",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    }
+  },
+  "Resources": {
+    "CustomerGateway": {
+      "Type": "AWS::EC2::CustomerGateway",
+      "Properties": {
+        "Type": "ipsec.1",
+        "IpAddress": {
+          "Ref": "IPSecTunnelTarget"
+        },
+        "BgpAsn": {
+          "Ref": "BgpAutonomousSystemNumber"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CustomerGateway"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "VpnGateway": {
+      "Type": "AWS::EC2::VPNGateway",
+      "Properties": {
+        "Type": "ipsec.1",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "VpnGateway"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "VpcVpnGatewayAttachment": {
+      "DependsOn": "VpnGateway",
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "VpnGatewayId": {
+          "Ref": "VpnGateway"
+        }
+      }
+    },
+    "VpcVpnConnection": {
+      "Type": "AWS::EC2::VPNConnection",
+      "DependsOn": "VpcVpnGatewayAttachment",
+      "Properties": {
+        "Type": "ipsec.1",
+        "CustomerGatewayId": {
+          "Ref": "CustomerGateway"
+        },
+        "StaticRoutesOnly": "False",
+        "VpnGatewayId": {
+          "Ref": "VpnGateway"
+        }
+      }
+    },
+    "PublicRouteTableRouteToDataCenter": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "VpcVpnConnection",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        },
+        "DestinationCidrBlock": {
+          "Ref": "DataCenterCidrBlock"
+        },
+        "GatewayId": {
+          "Ref": "VpnGateway"
+        }
+      },
+      "Metadata": {
+        "Comment": "You have to add routes to each route table pointing to the VPN gateway to make routing work"
+      }
+    },
+    "PublicRouteTableRouteToOffice": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "VpcVpnConnection",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        },
+        "DestinationCidrBlock": {
+          "Ref": "OfficeCidrBlock"
+        },
+        "GatewayId": {
+          "Ref": "VpnGateway"
+        }
+      },
+      "Metadata": {
+        "Comment": "You have to add routes to each route table pointing to the VPN gateway to make routing work"
+      }
+    },
+    "PrivateRouteTableAZ1RouteToDataCenter": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "VpcVpnGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ1"
+        },
+        "DestinationCidrBlock": {
+          "Ref": "DataCenterCidrBlock"
+        },
+        "GatewayId": {
+          "Ref": "VpnGateway"
+        }
+      },
+      "Metadata": {
+        "Comment": "You have to add routes to each route table pointing to the VPN gateway to make routing work"
+      }
+    },
+    "PrivateRouteTableAZ2RouteToDataCenter": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "VpcVpnGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ2"
+        },
+        "DestinationCidrBlock": {
+          "Ref": "DataCenterCidrBlock"
+        },
+        "GatewayId": {
+          "Ref": "VpnGateway"
+        }
+      },
+      "Metadata": {
+        "Comment": "You have to add routes to each route table pointing to the VPN gateway to make routing work"
+      }
+    },
+    "PrivateRouteTableAZ3RouteToDataCenter": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "VpcVpnGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ3"
+        },
+        "DestinationCidrBlock": {
+          "Ref": "DataCenterCidrBlock"
+        },
+        "GatewayId": {
+          "Ref": "VpnGateway"
+        }
+      },
+      "Metadata": {
+        "Comment": "You have to add routes to each route table pointing to the VPN gateway to make routing work"
+      }
+    },
+    "PrivateRouteTableAZ1RouteToOffice": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "VpcVpnGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ1"
+        },
+        "DestinationCidrBlock": {
+          "Ref": "OfficeCidrBlock"
+        },
+        "GatewayId": {
+          "Ref": "VpnGateway"
+        }
+      },
+      "Metadata": {
+        "Comment": "You have to add routes to each route table pointing to the VPN gateway to make routing work"
+      }
+    },
+    "PrivateRouteTableAZ2RouteToOffice": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "VpcVpnGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ2"
+        },
+        "DestinationCidrBlock": {
+          "Ref": "OfficeCidrBlock"
+        },
+        "GatewayId": {
+          "Ref": "VpnGateway"
+        }
+      },
+      "Metadata": {
+        "Comment": "You have to add routes to each route table pointing to the VPN gateway to make routing work"
+      }
+    },
+    "PrivateRouteTableAZ3RouteToOffice": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "VpcVpnGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTableAZ3"
+        },
+        "DestinationCidrBlock": {
+          "Ref": "OfficeCidrBlock"
+        },
+        "GatewayId": {
+          "Ref": "VpnGateway"
+        }
+      },
+      "Metadata": {
+        "Comment": "You have to add routes to each route table pointing to the VPN gateway to make routing work"
+      }
+    }
+  }
+}

--- a/vpc/vpc.README.md
+++ b/vpc/vpc.README.md
@@ -1,0 +1,71 @@
+﻿## VPC Stack
+
+To use this stack you will need to set the required input parameters and include the stack as a resource.
+
+#### Example input definition
+```json
+    "StacksVersion": {
+      "Description": "Version of Nubis Stacks to use for the nested stacks.",
+      "Type": "String",
+      "Default": "v1.0.0"
+    },
+```
+
+### Stack options
+This stack creates the VPC and a set of public subnets in three seperate availability zones. This template can also create some optional resources; private subnets with nat instances and a vpn connection.
+
+To enable creation of the private subnets and their associated nat instances you must provide the three PrivateSubnetAZXCidr inputs. Omitting any one of them will disable private subnet creation.
+
+To enable creation of the vpn connection you must provide the IPSecTunnelTarget input. Omitting this input will disable vpn creation. You must create the private subnets in order to create the vpn connection.
+
+#### Example resource definition
+```json
+    "VPCStack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "TemplateURL": { "Fn::Join": [ "/", [ "https://s3.amazonaws.com/nubisproject-stacks", { "Ref": "StacksVersion" }, "vpc/vpc-private-subnet.template" ] ] },
+        "TimeoutInMinutes": "60",
+        "Parameters": {
+          "ServiceName": {
+            "Ref": "ServiceName"
+          },
+          "TechnicalOwner": {
+            "Ref": "TechnicalOwner"
+          },
+          "Environment": {
+            "Ref": "Environment"
+          },
+          "StacksVersion": {
+            "Ref": "StacksVersion"
+          },
+          "VpcCidr": {
+            "Ref": "VpcCidr"
+          },
+          "PublicSubnetAZ1Cidr": {
+            "Ref": "PublicSubnetAZ1Cidr"
+          },
+          "PublicSubnetAZ2Cidr": {
+            "Ref": "PublicSubnetAZ2Cidr"
+          },
+          "PublicSubnetAZ3Cidr": {
+            "Ref": "PublicSubnetAZ3Cidr"
+          },
+          "PrivateSubnetAZ1Cidr": {
+            "Ref": "PrivateSubnetAZ1Cidr"
+          },
+          "PrivateSubnetAZ2Cidr": {
+            "Ref": "PrivateSubnetAZ2Cidr"
+          },
+          "PrivateSubnetAZ3Cidr": {
+            "Ref": "PrivateSubnetAZ3Cidr"
+          },
+          "SSHKeyName": {
+            "Ref": "SSHKeyName"
+          },
+          "IPSecTunnelTarget": {
+            "Ref": "IPSecTunnelTarget"
+          }
+        }
+      }
+    }
+```

--- a/vpc/vpc.template
+++ b/vpc/vpc.template
@@ -1,0 +1,674 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "A VPC containing 3 public subnets, optionally 3 private subnets with 3 NATs and a VPN connection",
+  "Parameters": {
+    "ServiceName": {
+      "Description": "Name of this deployment",
+      "AllowedPattern": "^[a-z0-9][a-z0-9-.]*$",
+      "Type": "String"
+    },
+    "TechnicalOwner": {
+      "Description": "A valid LDAP email",
+      "AllowedPattern": "^([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$",
+      "Type": "String"
+    },
+    "Environment": {
+      "Description": "The name of the environment we are deploying into: sandbox, stage, or production.",
+      "Type": "String",
+      "AllowedValues": [
+        "sandbox",
+        "stage",
+        "prod",
+        "admin"
+      ],
+      "Default": "sandbox",
+      "ConstraintDescription": "must be one of these types of Mozilla VPCs"
+    },
+    "StacksVersion": {
+      "Description": "Version of Nubis Stacks to use for the nested stacks.",
+      "Type": "String",
+      "Default": "v1.0.0"
+    },
+    "VpcCidr": {
+      "Description": "The CIDR for the VPC Subnet.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "NubisDomain": {
+      "Description": "The domain used for DHCP Search.",
+      "Default": "nubis.allizom.org",
+      "AllowedPattern": "^[0-9a-z\\-\\.]+$",
+      "Type": "String"
+    },
+    "PublicSubnetAZ1Cidr": {
+      "Description": "The CIDR for the Public Subnet in Availability Zone 1.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "PublicSubnetAZ2Cidr": {
+      "Description": "The CIDR for the Public Subnet in Availability Zone 2.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "PublicSubnetAZ3Cidr": {
+      "Description": "The CIDR for the Public Subnet in Availability Zone 3.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "PrivateSubnetAZ1Cidr": {
+      "Description": "The CIDR for the Private Subnet in Availability Zone 1.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "Default": "0.0.0.0/32",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "PrivateSubnetAZ2Cidr": {
+      "Description": "The CIDR for the Private Subnet in Availability Zone 2.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "Default": "0.0.0.0/32",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "PrivateSubnetAZ3Cidr": {
+      "Description": "The CIDR for the Private Subnet in Availability Zone 3.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "19",
+      "Default": "0.0.0.0/32",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))/([0-9]|[12][0-9]|3[0-2])",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "SSHKeyName": {
+      "Description": "Name of an existing EC2 SSH KeyPair to install on the instance",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription": "Must be the name of an existing EC2 KeyPair."
+    },
+    "IPSecTunnelTarget": {
+      "Description": "The IP address of our firewall where the IPSec tunnels will terminate",
+      "Type": "String",
+      "MinLength": "7",
+      "MaxLength": "15",
+      "Default": "0.0.0.0",
+      "AllowedPattern": "^([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5])).([0-9]|[1-9][0-9]|1[0-9]{2}|2([0-4][0-9]|5[0-5]))",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x"
+    }
+  },
+  "Conditions": {
+    "CreatePrivateSubnets": {
+      "Fn::Not": [
+        {
+          "Fn::Or": [
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "PrivateSubnetAZ1Cidr"
+                },
+                "0.0.0.0/32"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "PrivateSubnetAZ2Cidr"
+                },
+                "0.0.0.0/32"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "PrivateSubnetAZ3Cidr"
+                },
+                "0.0.0.0/32"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "CreateVPNResources": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "IPSecTunnelTarget"
+            },
+            "0.0.0.0"
+          ]
+        }
+      ]
+    }
+  },
+  "Resources": {
+    "NubisVpc": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true",
+        "CidrBlock": {
+          "Ref": "VpcCidr"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Ref": "AWS::Region"
+                  },
+                  {
+                    "Ref": "Environment"
+                  },
+                  "VPC"
+                ]
+              ]
+            }
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "VpcDhcpOptionsAssociation": {
+      "Type": "AWS::EC2::VPCDHCPOptionsAssociation",
+      "Properties": {
+        "VpcId": {
+          "Ref": "NubisVpc"
+        },
+        "DhcpOptionsId": {
+          "Ref": "DhcpOptions"
+        }
+      }
+    },
+    "DhcpOptions": {
+      "Type": "AWS::EC2::DHCPOptions",
+      "Properties": {
+        "DomainName": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Fn::Join": [
+                  ".",
+                  [
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "compute.internal"
+                  ]
+                ]
+              },
+              {
+                "Fn::Join": [
+                  ".",
+                  [
+                    {
+                      "Ref": "Environment"
+                    },
+                    {
+                      "Ref": "NubisDomain"
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        "DomainNameServers": [
+          "AmazonProvidedDNS"
+        ]
+      }
+    },
+    "SharedServicesSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "VpcId": {
+          "Ref": "NubisVpc"
+        },
+        "GroupDescription": "The security group for all instances.",
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "icmp",
+            "FromPort": "8",
+            "ToPort": "-1",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "SharedServicesSecurityGroup"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      }
+    },
+    "SssgAllowConsulTcpIn": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        },
+        "IpProtocol": "tcp",
+        "FromPort": "8300",
+        "ToPort": "8302",
+        "SourceSecurityGroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        }
+      }
+    },
+    "SssgAllowConsulUdpIn": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        },
+        "IpProtocol": "udp",
+        "FromPort": "8300",
+        "ToPort": "8302",
+        "SourceSecurityGroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        }
+      }
+    },
+    "SssgAllowAnyTcpOut": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        },
+        "IpProtocol": "tcp",
+        "FromPort": "0",
+        "ToPort": "65535",
+        "SourceSecurityGroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        }
+      }
+    },
+    "SssgAllowAnyUdpOut": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        },
+        "IpProtocol": "udp",
+        "FromPort": "0",
+        "ToPort": "65535",
+        "SourceSecurityGroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        }
+      }
+    },
+    "SssgAllowAnyIcmpOut": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        },
+        "IpProtocol": "icmp",
+        "FromPort": "-1",
+        "ToPort": "-1",
+        "SourceSecurityGroupId": {
+          "Ref": "SharedServicesSecurityGroup"
+        }
+      }
+    },
+    "InternetAccessSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "VpcId": {
+          "Ref": "NubisVpc"
+        },
+        "GroupDescription": "Internet Access security group",
+        "SecurityGroupEgress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": "0.0.0.0/0"
+          },
+          {
+            "IpProtocol": "udp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": "0.0.0.0/0"
+          },
+          {
+            "IpProtocol": "icmp",
+            "FromPort": "-1",
+            "ToPort": "-1",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "InternetAccessSecurityGroup"
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      },
+      "Metadata": {
+        "Comment": "This security group must be applied to any instances that need to get out to the Internet."
+      }
+    },
+    "PublicSubnetStack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "TemplateURL": {
+          "Fn::Join": [
+            "/",
+            [
+              "https://s3.amazonaws.com/nubisproject-stacks",
+              {
+                "Ref": "StacksVersion"
+              },
+              "vpc/vpc-public-subnet.template"
+            ]
+          ]
+        },
+        "TimeoutInMinutes": "60",
+        "Parameters": {
+          "VpcId": {
+            "Ref": "NubisVpc"
+          },
+          "ServiceName": {
+            "Ref": "ServiceName"
+          },
+          "TechnicalOwner": {
+            "Ref": "TechnicalOwner"
+          },
+          "Environment": {
+            "Ref": "Environment"
+          },
+          "PublicSubnetAZ1Cidr": {
+            "Ref": "PublicSubnetAZ1Cidr"
+          },
+          "PublicSubnetAZ2Cidr": {
+            "Ref": "PublicSubnetAZ2Cidr"
+          },
+          "PublicSubnetAZ3Cidr": {
+            "Ref": "PublicSubnetAZ3Cidr"
+          }
+        }
+      }
+    },
+    "PrivateSubnetStack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Condition": "CreatePrivateSubnets",
+      "DependsOn": "PublicSubnetStack",
+      "Properties": {
+        "TemplateURL": {
+          "Fn::Join": [
+            "/",
+            [
+              "https://s3.amazonaws.com/nubisproject-stacks",
+              {
+                "Ref": "StacksVersion"
+              },
+              "vpc/vpc-private-subnet.template"
+            ]
+          ]
+        },
+        "TimeoutInMinutes": "60",
+        "Parameters": {
+          "VpcId": {
+            "Ref": "NubisVpc"
+          },
+          "ServiceName": {
+            "Ref": "ServiceName"
+          },
+          "TechnicalOwner": {
+            "Ref": "TechnicalOwner"
+          },
+          "Environment": {
+            "Ref": "Environment"
+          },
+          "PrivateSubnetAZ1Cidr": {
+            "Ref": "PrivateSubnetAZ1Cidr"
+          },
+          "PrivateSubnetAZ2Cidr": {
+            "Ref": "PrivateSubnetAZ2Cidr"
+          },
+          "PrivateSubnetAZ3Cidr": {
+            "Ref": "PrivateSubnetAZ3Cidr"
+          },
+          "SSHKeyName": {
+            "Ref": "SSHKeyName"
+          },
+          "PublicSubnetAZ1": {
+            "Fn::GetAtt": [
+              "PublicSubnetStack",
+              "Outputs.PublicSubnetAZ1"
+            ]
+          },
+          "PublicSubnetAZ2": {
+            "Fn::GetAtt": [
+              "PublicSubnetStack",
+              "Outputs.PublicSubnetAZ2"
+            ]
+          },
+          "PublicSubnetAZ3": {
+            "Fn::GetAtt": [
+              "PublicSubnetStack",
+              "Outputs.PublicSubnetAZ3"
+            ]
+          },
+          "InternetAccessSecurityGroup": {
+            "Ref": "InternetAccessSecurityGroup"
+          }
+        }
+      }
+    },
+    "VPNStack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Condition": "CreateVPNResources",
+      "DependsOn": "PrivateSubnetStack",
+      "Properties": {
+        "TemplateURL": {
+          "Fn::Join": [
+            "/",
+            [
+              "https://s3.amazonaws.com/nubisproject-stacks",
+              {
+                "Ref": "StacksVersion"
+              },
+              "vpc/vpc-vpn.template"
+            ]
+          ]
+        },
+        "TimeoutInMinutes": "60",
+        "Parameters": {
+          "VpcId": {
+            "Ref": "NubisVpc"
+          },
+          "ServiceName": {
+            "Ref": "ServiceName"
+          },
+          "TechnicalOwner": {
+            "Ref": "TechnicalOwner"
+          },
+          "Environment": {
+            "Ref": "Environment"
+          },
+          "PublicRouteTable": {
+            "Fn::GetAtt": [
+              "PublicSubnetStack",
+              "Outputs.PublicRouteTable"
+            ]
+          },
+          "PrivateRouteTableAZ1": {
+            "Fn::GetAtt": [
+              "PrivateSubnetStack",
+              "Outputs.PrivateRouteTableAZ1"
+            ]
+          },
+          "PrivateRouteTableAZ2": {
+            "Fn::GetAtt": [
+              "PrivateSubnetStack",
+              "Outputs.PrivateRouteTableAZ2"
+            ]
+          },
+          "PrivateRouteTableAZ3": {
+            "Fn::GetAtt": [
+              "PrivateSubnetStack",
+              "Outputs.PrivateRouteTableAZ3"
+            ]
+          },
+          "IPSecTunnelTarget": {
+            "Ref": "IPSecTunnelTarget"
+          }
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ServiceName": {
+      "Description": "Name of this deployment.",
+      "Value": {
+        "Ref": "ServiceName"
+      }
+    },
+    "Environment": {
+      "Description": "The VPC environment.",
+      "Value": {
+        "Ref": "Environment"
+      }
+    },
+    "VpcId": {
+      "Description": "The ID of the VPC that was created.",
+      "Value": {
+        "Ref": "NubisVpc"
+      }
+    },
+    "PublicSubnetAZ1": {
+      "Value": {
+        "Fn::GetAtt": [
+          "PublicSubnetStack",
+          "Outputs.PublicSubnetAZ1"
+        ]
+      }
+    },
+    "PublicSubnetAZ2": {
+      "Value": {
+        "Fn::GetAtt": [
+          "PublicSubnetStack",
+          "Outputs.PublicSubnetAZ2"
+        ]
+      }
+    },
+    "PublicSubnetAZ3": {
+      "Value": {
+        "Fn::GetAtt": [
+          "PublicSubnetStack",
+          "Outputs.PublicSubnetAZ3"
+        ]
+      }
+    },
+    "PrivateSubnetAZ1": {
+      "Condition": "CreatePrivateSubnets",
+      "Value": {
+        "Fn::GetAtt": [
+          "PrivateSubnetStack",
+          "Outputs.PrivateSubnetAZ1"
+        ]
+      }
+    },
+    "PrivateSubnetAZ2": {
+      "Condition": "CreatePrivateSubnets",
+      "Value": {
+        "Fn::GetAtt": [
+          "PrivateSubnetStack",
+          "Outputs.PrivateSubnetAZ1"
+        ]
+      }
+    },
+    "PrivateSubnetAZ3": {
+      "Condition": "CreatePrivateSubnets",
+      "Value": {
+        "Fn::GetAtt": [
+          "PrivateSubnetStack",
+          "Outputs.PrivateSubnetAZ1"
+        ]
+      }
+    },
+    "SharedServicesSecurityGroupId": {
+      "Value": {
+        "Ref": "SharedServicesSecurityGroup"
+      }
+    },
+    "InternetAccessSecurityGroupId": {
+      "Value": {
+        "Ref": "InternetAccessSecurityGroup"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Restructure templates to make multiple deployments to multiple accounts possible.

Closes:
- https://github.com/Nubisproject/nubis-vpc/issues/25
- https://github.com/Nubisproject/nubis-vpc/issues/24
- https://github.com/Nubisproject/nubis-vpc/issues/22
- https://github.com/Nubisproject/nubis-vpc/issues/23

Also adds better logic for directory uploads to upload_to_s3 helper script. Plus add single file upload validation to same.
