### PR TITLE
Remove AvailabilityZones from ec2.template

### DIFF
--- a/ec2.template
+++ b/ec2.template
@@ -438,9 +438,6 @@
         }
       },
       "Properties": {
-        "AvailabilityZones": {
-          "Fn::GetAZs": ""
-        },
         "VPCZoneIdentifier": [
           {
             "Fn::GetAtt": [
@@ -548,9 +545,6 @@
         }
       },
       "Properties": {
-        "AvailabilityZones": {
-          "Fn::GetAZs": ""
-        },
         "VPCZoneIdentifier": [
           {
             "Fn::GetAtt": [


### PR DESCRIPTION
AvailabilityZones are not necessary when declaring VPCZoneIdentifiers. Only one or the other is necessary. Removing AvailabilityZones solves the us-east-1 deployment issue.
