### PR TITLE
Remove AvailabilityZones for us-east-1 deployments

### DIFF
--- a/storage.template
+++ b/storage.template
@@ -434,9 +434,6 @@
         }
       },
       "Properties": {
-        "AvailabilityZones": {
-          "Fn::GetAZs": ""
-        },
         "VPCZoneIdentifier": [
           {
             "Fn::GetAtt": [


### PR DESCRIPTION
Do not need to specify AvailabilityZones when specifying VPCZoneIdentifiers
