### PR TITLE
Add SshSecurityGroup

### DIFF
--- a/ec2.template
+++ b/ec2.template
@@ -250,7 +250,12 @@
             "IpProtocol": "tcp",
             "FromPort": "22",
             "ToPort": "22",
-            "CidrIp": "0.0.0.0/0"
+            "SourceSecurityGroupId": {
+              "Fn::GetAtt": [
+                "VpcInfo",
+                "SshSecurityGroupId"
+              ]
+            }
           },
           {
             "IpProtocol": "tcp",
@@ -330,6 +335,12 @@
             "Fn::GetAtt": [
               "VpcInfo",
               "SharedServicesSecurityGroupId"
+            ]
+          },
+          {
+            "Fn::GetAtt": [
+              "VpcInfo",
+              "SshSecurityGroupId"
             ]
           }
         ],

--- a/vpc/vpc.template
+++ b/vpc/vpc.template
@@ -398,6 +398,62 @@
         "Comment": "This security group must be applied to any instances that need to get out to the Internet."
       }
     },
+    "SshSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "VpcId": {
+          "Ref": "NubisVpc"
+        },
+        "GroupDescription": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Ref": "Environment"
+              },
+              "SSH Security Group"
+            ]
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "Environment"
+                  },
+                  "SshSecurityGroup"
+                ]
+              ]
+            }
+          },
+          {
+            "Key": "ServiceName",
+            "Value": {
+              "Ref": "ServiceName"
+            }
+          },
+          {
+            "Key": "TechnicalOwner",
+            "Value": {
+              "Ref": "TechnicalOwner"
+            }
+          },
+          {
+            "Key": "Environment",
+            "Value": {
+              "Ref": "Environment"
+            }
+          }
+        ]
+      },
+      "Metadata": {
+        "Comment": "This security group must be applied to any instances that need inbound ssh access."
+      }
+    },
     "PublicSubnetStack": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
@@ -673,6 +729,11 @@
     "InternetAccessSecurityGroupId": {
       "Value": {
         "Ref": "InternetAccessSecurityGroup"
+      }
+    },
+    "SshSecurityGroupId": {
+      "Value": {
+        "Ref": "SshSecurityGroup"
       }
     }
   }


### PR DESCRIPTION
Adding a security group to restrict inbound ssh access to only hosts in this group. The group is created in the VPC stack and exposed through stack outputs. The same stack sets this group as the inbound access group for the EC2SecurityGroup port 22 access.

Closes #96 
