### PR TITLE
Add a new ELB boolean, AccessLogging (default:false) that enables ELB logging.

### DIFF
--- a/elb.template
+++ b/elb.template
@@ -34,9 +34,32 @@
       "Type": "String",
       "AllowedPattern": "^arn:aws:iam::[0-9]+:server-certificate/.*$",
       "Default": "arn:aws:iam::0000:server-certificate/not-set"
+    },
+    "AccessLogging": {
+      "Description": "Flag to enable Access Logging to an S3 bucket",
+      "Type": "String",
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "ConstraintDescription": "Must be true or false",
+      "Default": "false"
+    },
+    "StacksVersion": {
+      "Description": "Version of the Nubis Stacks",
+      "Type": "String",
+      "Default": "v1.0.0"
     }
   },
   "Conditions": {
+    "AccessLogging": {
+      "Fn::Equals": [
+        {
+          "Ref": "AccessLogging"
+        },
+        "true"
+      ]
+    },
     "NotSet_SSLCertificate": {
       "Fn::Equals": [
         {
@@ -44,6 +67,46 @@
         },
         "arn:aws:iam::0000:server-certificate/not-set"
       ]
+    }
+  },
+  "Mappings": {
+    "ELBAccountIdMap": {
+      "Comment": {
+        "Comment": "This maps to the accounts running ELBs"
+      },
+      "us-east-1": {
+        "AccountId": "127311923021"
+      },
+      "us-west-1": {
+        "AccountId": "027434742980"
+      },
+      "us-west-2": {
+        "AccountId": "797873946194"
+      },
+      "eu-west-1": {
+        "AccountId": "156460612806"
+      },
+      "eu-central-1": {
+        "AccountId": "054676820928"
+      },
+      "ap-northeast-1": {
+        "AccountId": "582318560864"
+      },
+      "ap-southeast-1": {
+        "AccountId": "114774131450"
+      },
+      "ap-southeast-2": {
+        "AccountId": "783225319266"
+      },
+      "sa-east-1": {
+        "AccountId": "507241528517"
+      },
+      "us-gov-west-1": {
+        "AccountId": "048591011584"
+      },
+      "cn-north-1": {
+        "AccountId": "638102146993"
+      }
     }
   },
   "Resources": {
@@ -114,6 +177,29 @@
         },
         "SearchString": {
           "Ref": "Environment"
+        }
+      }
+    },
+    "AccessLoggingBucketUUID": {
+      "Type": "Custom::UUID",
+      "Condition": "AccessLogging",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:lambda:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":function:",
+              "UUID"
+            ]
+          ]
         }
       }
     },
@@ -253,6 +339,24 @@
           },
           "Interval": "30"
         },
+        "AccessLoggingPolicy": {
+          "Fn::If": [
+            "AccessLogging",
+            {
+              "EmitInterval": 5,
+              "Enabled": true,
+              "S3BucketName": {
+                "Fn::GetAtt": [
+                  "AccessLoggingBucket",
+                  "Outputs.S3Bucket"
+                ]
+              }
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
         "Tags": [
           {
             "Key": "ServiceName",
@@ -285,6 +389,95 @@
             "Value": "Never"
           }
         ]
+      }
+    },
+    "AccessLoggingBucket": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Condition": "AccessLogging",
+      "Properties": {
+        "TemplateURL": { "Fn::Join": [ "/", [ "https://s3.amazonaws.com/nubis-stacks", { "Ref": "StacksVersion" }, "s3-bucket.template" ] ] },
+        "Parameters": {
+          "ServiceName": {
+            "Ref": "ServiceName"
+          },
+          "TechnicalOwner": {
+            "Ref": "TechnicalOwner"
+          },
+          "Environment": {
+            "Ref": "Environment"
+          },
+          "AccessControl": "Private",
+          "BucketName": {
+            "Fn::Join": [
+              "-",
+              [
+                {
+                  "Ref": "ServiceName"
+                },
+                {
+                  "Ref": "Environment"
+                },
+                "elb",
+                {
+                  "Fn::GetAtt": [
+                    "AccessLoggingBucketUUID",
+                    "uuid"
+                  ]
+                }
+              ]
+            ]
+          }
+        }
+      }
+    },
+    "AccessLoggingBucketPolicy": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Condition": "AccessLogging",
+      "Properties": {
+        "Bucket": {
+          "Fn::GetAtt": [
+            "AccessLoggingBucket",
+            "Outputs.S3Bucket"
+          ]
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:PutObject"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Fn::GetAtt": [
+                        "AccessLoggingBucket",
+                        "Outputs.S3Bucket"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              },
+              "Principal": {
+                "AWS": [
+                  {
+                    "Fn::FindInMap": [
+                      "ELBAccountIdMap",
+                      {
+                        "Ref": "AWS::Region"
+                      },
+                      "AccountId"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
       }
     }
   },


### PR DESCRIPTION
The effect of this is:
- Creation of a S3 bucket, unique for that ELB
- Creation of a bucket policy, that grants putObject to AWS ELBs
- Configures the ELB to drop logs there every 5 minutes (lowest setting)
