### PR TITLE
Since we use UUID for our ELB bucket names, we don't really need to uniquely prefix them with the account name, so don't.

### DIFF
--- a/vpc/vpc.template
+++ b/vpc/vpc.template
@@ -236,9 +236,6 @@
               "-",
               [
                 {
-                  "Ref": "ServiceName"
-                },
-                {
                   "Ref": "Environment"
                 },
                 "elb",


### PR DESCRIPTION
Fixes #182
