### PR TITLE
Create group to enforce MFA

### DIFF
--- a/vpc/vpc-meta.template
+++ b/vpc/vpc-meta.template
@@ -128,6 +128,15 @@
           "Arn"
         ]
       }
+    },
+    "AdminMFAGroupArn": {
+      "Description": "ARN of AdminMFA group",
+      "Value": {
+        "Fn::GetAtt": [
+          "AdminMFAGroup",
+          "Arn"
+        ]
+      }
     }
   },
   "Resources": {
@@ -412,6 +421,155 @@
         },
         "Runtime": "nodejs",
         "Timeout": "25"
+      }
+    },
+    "AdminMFAGroup": {
+      "Type": "AWS::IAM::Group",
+      "Properties": {
+        "ManagedPolicyArns": [
+          {
+            "Ref": "ForceMFA"
+          },
+          {
+            "Ref": "NubisAdmin"
+          }
+        ]
+      }
+    },
+    "ForceMFA": {
+      "Type": "AWS::IAM::ManagedPolicy",
+      "Properties": {
+        "Description": "A policy to enforce MFA on admin accounts",
+        "Path": "/",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowAllUsersToListAccounts",
+              "Effect": "Allow",
+              "Action": [
+                "iam:ListUsers",
+                "iam:ListAccountAliases"
+              ],
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":user/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Sid": "AllowIndividualUserToSeeTheirAccountInformation",
+              "Effect": "Allow",
+              "Action": [
+                "iam:ChangePassword",
+                "iam:CreateLoginProfile",
+                "iam:DeleteLoginProfile",
+                "iam:GetAccountPasswordPolicy",
+                "iam:GetAccountSummary",
+                "iam:GetLoginProfile",
+                "iam:UpdateLoginProfile"
+              ],
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":user/${aws:username}"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Sid": "AllowIndividualUserToListTheirMFA",
+              "Effect": "Allow",
+              "Action": [
+                "iam:ListVirtualMFADevices",
+                "iam:ListMFADevices"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "AllowIndividualUserToManageThierMFA",
+              "Effect": "Allow",
+              "Action": [
+                "iam:CreateVirtualMFADevice",
+                "iam:DeactivateMFADevice",
+                "iam:DeleteVirtualMFADevice",
+                "iam:EnableMFADevice",
+                "iam:ResyncMFADevice"
+              ],
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":mfa/${aws:username}"
+                    ]
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":user/${aws:username}"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Sid": "DoNotAllowAnythingOtherThanAboveUnlessMFAd",
+              "Effect": "Deny",
+              "NotAction": "iam:*",
+              "Resource": "*",
+              "Condition": {
+                "Null": {
+                  "aws:MultiFactorAuthAge": "true"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "NubisAdmin": {
+      "Type": "AWS::IAM::ManagedPolicy",
+      "DependsOn": "ForceMFA",
+      "Properties": {
+        "Description": "Nubis Admin",
+        "Path": "/",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "*",
+              "Resource": "*"
+            }
+          ]
+        }
       }
     }
   }


### PR DESCRIPTION
Creates an admin group and attaches 2 policies. One policy makes sure that we need to use MFA the other makes us an administrator. Issue for this is being tracked at nubisproject/nubis-meta#19

If this change happen there needs to be a change in workflow.

> One side effect when enforcing MFA be used to log into the console. The IAM user will not be able to use the API/AWS CLI directly with their access keys. Meaning API calls will also require MFA. The user will need to make getSessionToken API call to request a set of temporary credentials with the serial code provided by MFA device

The commands that we care about for getting temporary access via the CLI is as follows:

``` bash
Virtual MFA: aws sts get-session-token --serial-number arn:aws:iam::123456789012:mfa/username --token-code xxxxx 
Physical MFA: aws sts get-session-token --serial-number serialnumber --token-code xxxxx
```
