### PR TITLE
[RDS] Updated to reflect actual limits:

### DIFF
--- a/rds-mysql.template
+++ b/rds-mysql.template
@@ -61,8 +61,8 @@
     "DBName": {
       "Description": "Name of this deployment",
       "Type": "String",
-      "AllowedPattern": "[a-zA-Z0-9]{1,15}",
-      "ConstraintDescription": "Must only contain upper and lower case letters and numbers, between 1 and 15 characters."
+      "AllowedPattern": "[a-zA-Z0-9_]{1,64}",
+      "ConstraintDescription": "Must only contain upper and lower case letters and numbers, between 1 and 64 characters."
     },
     "EC2SecurityGroup": {
       "Description": "EC2SecurityGroup id",

--- a/rds-postgres.template
+++ b/rds-postgres.template
@@ -61,8 +61,8 @@
     "DBName": {
       "Description": "Name of this deployment",
       "Type": "String",
-      "AllowedPattern": "[a-zA-Z0-9]{1,15}",
-      "ConstraintDescription": "Must only contain upper and lower case letters and numbers, between 1 and 15 characters."
+      "AllowedPattern": "[a-zA-Z_][a-zA-Z0-9_]{0,62}",
+      "ConstraintDescription": "Must only contain upper and lower case letters and numbers, between 1 and 63 characters."
     },
     "EC2SecurityGroup": {
       "Description": "EC2SecurityGroup id",


### PR DESCRIPTION
MySQL and MariaDB
    Must contain 1 to 64 alphanumeric characters.

PostgreSQL
    Must contain 1 to 63 alphanumeric characters.

```
Must begin with a letter or an underscore. Subsequent characters can be letters, underscores, or digits (0-9).
```
