### PR TITLE
Revert "Add Network ACL Administrators group and policies"

### DIFF
--- a/vpc/vpc-meta.template
+++ b/vpc/vpc-meta.template
@@ -226,28 +226,6 @@
         ]
       }
     },
-    "NACLAdminGroup": {
-      "Type": "AWS::IAM::Group",
-      "Properties": {
-        "NACLAdminPolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "ec2:CreateNetworkAclEntry",
-                "ec2:DeleteNetworkAclEntry",
-                "ec2:DescribeNetworkAcls",
-                "ec2:ReplaceNetworkAclEntry",
-                "ec2:DescribeVpcAttribute",
-                "ec2:DescribeVpcs"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ]
-        }
-      }
-    },
     "NubisMySQL56ParameterGroup": {
       "Type": "AWS::RDS::DBParameterGroup",
       "Properties": {


### PR DESCRIPTION
Reverts nubisproject/nubis-stacks#193

This breaks VPC deployments. This policy is not valid. See errors below:

09:16:32 UTC-0700   UPDATE_ROLLBACK_IN_PROGRESS     AWS::CloudFormation::Stack  us-east-1-vpc-VPCMetaStack-7N2FEGMUPZSX     The following resource(s) failed to create: [NACLAdminGroup].
09:16:31 UTC-0700   CREATE_FAILED   AWS::IAM::Group     NACLAdminGroup  Encountered unsupported property NACLAdminPolicyDocument
