### PR TITLE
Add ReadOnlyUsers group and policy

### DIFF
--- a/vpc/vpc-meta.template
+++ b/vpc/vpc-meta.template
@@ -253,6 +253,12 @@
         ]
       }
     },
+    "ReadOnlyUsers": {
+      "Type": "AWS::IAM::Group",
+      "Properties": {
+        "ManagedPolicyArns": [ "arn:aws:iam::aws:policy/ReadOnlyAccess" ]
+      }
+    },
     "NubisMySQL56ParameterGroup": {
       "Type": "AWS::RDS::DBParameterGroup",
       "Properties": {


### PR DESCRIPTION
Adding an IAM Group called ReadOnlyUsers, along with the managed
ReadOnlyAccess policy.

Sorry that I haven't yet figured out how to configure my editor to stop removing EOL at the end of the file.
