### PR TITLE
Make the Purpose tag a bit more strict, accepting only DNS-hostname safe patterns

### DIFF
--- a/ec2.template
+++ b/ec2.template
@@ -165,8 +165,8 @@
     "Purpose": {
       "Description": "Purpose of this stack (Web Server, Job Runner, Database, etc)",
       "Type": "String",
-      "AllowedPattern": "^[a-zA-Z0-9 ]+$",
-      "Default": "Web Server"
+      "AllowedPattern": "^[a-zA-Z]([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])?$",
+      "Default": "WebServer"
     }
   },
   "Conditions": {


### PR DESCRIPTION
Fixes #280
